### PR TITLE
fix(token): correct token return value

### DIFF
--- a/pkg/cloudflare/token.go
+++ b/pkg/cloudflare/token.go
@@ -89,6 +89,6 @@ func GenerateToken(
 		return "", fmt.Errorf("%w: %w", ErrCreateTokenFailed, err)
 	}
 
-	// Return the generated token’s ID.
-	return token.ID, nil
+	// Return the generated token’s Value.
+	return token.Value, nil
 }

--- a/pkg/cloudflare/token_test.go
+++ b/pkg/cloudflare/token_test.go
@@ -46,13 +46,13 @@ func TestGenerateToken(t *testing.T) {
 			serviceName: "test-service",
 			zone:        "example.com",
 			zoneID:      "zone-id-123",
-			wantToken:   "new-token",
+			wantToken:   "abcdefghijklmnopqrstuvwxyz1234567890ABCD",
 			setupMock: func(m *mocks.MockAPIInterface) {
 				m.On("ListZones", mock.Anything, mock.AnythingOfType("zones.ZoneListParams")).
 					Return(&pagination.V4PagePaginationArray[zones.Zone]{Result: []zones.Zone{{ID: "zone-id-123", Name: "example.com"}}}, nil).
 					Once()
 				m.On("CreateAPIToken", mock.Anything, mock.AnythingOfType("user.TokenNewParams")).
-					Return(&user.TokenNewResponse{ID: "new-token"}, nil).
+					Return(&user.TokenNewResponse{Value: "abcdefghijklmnopqrstuvwxyz1234567890ABCD"}, nil).
 					Once()
 			},
 		},


### PR DESCRIPTION
- Return the token value instead of the id.
- See cloudflare-go's api documentation for return options:
<https://pkg.go.dev/github.com/cloudflare/cloudflare-go/v4@v4.2.0/user#TokenNewResponse.ID>