### PR TITLE
fix(version): export version for goreleaser to dynamically adjust

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ builds:
       - arm
       - arm64
     ldflags:
-      - -s -w -X github.com/nicholas-fedor/gogeneratecftoken/cmd.version={{.Version}}
+      - -s -w -X github.com/nicholas-fedor/gogeneratecftoken/cmd.Version={{.Version}}
 
 archives:
   - id: default

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,8 +29,8 @@ import (
 )
 
 var (
-	// version defines the CLI tool's version.
-	version = "0.0.1"
+	// Version defines the CLI tool's Version.
+	Version = "0.0.1"
 	// goos holds the operating system type for determining configuration paths.
 	// It defaults to runtime.GOOS but can be overridden for testing.
 	goos = runtime.GOOS
@@ -62,7 +62,7 @@ Instructions:
 Example:
   Zone: example.com
   Command: goGenerateCFToken generate service
-  Output: 
+  Output:
 	Token Name: service.example.com
 	Token Value: (random token value)
 
@@ -72,7 +72,7 @@ Example:
 // rootCmd defines the root command for the CLI tool.
 var rootCmd = &cobra.Command{
 	Use:     "goGenerateCFToken",
-	Version: version,
+	Version: Version,
 	Short:   shortDescription,
 	Long:    longDescription,
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -34,8 +34,8 @@ func TestRootCmd(t *testing.T) {
 		t.Errorf("rootCmd.Use = %q, want %q", rootCmd.Use, "goGenerateCFToken")
 	}
 
-	if rootCmd.Version != version {
-		t.Errorf("rootCmd.Version = %q, want %q", rootCmd.Version, version)
+	if rootCmd.Version != Version {
+		t.Errorf("rootCmd.Version = %q, want %q", rootCmd.Version, Version)
 	}
 
 	if rootCmd.Short == "" || rootCmd.Long == "" {


### PR DESCRIPTION
- Export the `version` variable to enable Goreleaser to dynamically update it at build time.