### PR TITLE
Resolve Token Type Mismatch and Enhance Build Process

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,43 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Normalize all text files to LF line endings
+* text=auto eol=lf
+
+# Explicitly set Go-related text files to LF
+*.go text eol=lf
+*.mod text eol=lf
+*.sum text eol=lf
+*.work text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.json text eol=lf
+*.proto text eol=lf
+
+# Treat configuration and script files as text with LF
+*.toml text eol=lf
+*.ini text eol=lf
+*.sh text eol=lf
+Dockerfile text eol=lf
+*.dockerignore text eol=lf
+*.gitignore text eol=lf
+*.gitattributes text eol=lf
+
+# Treat binary files as binary (no line-ending conversion or diff)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.exe binary
+*.dll binary
+*.so binary
+*.db binary
+*.sqlite binary
+
+# Ensure generated Go binaries or test caches are treated as binary
+*.out binary
+*.test binary

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,12 @@ jobs:
         with:
           go-version: 1.24.5
 
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@0931acf1f7634c2ee911eea11a334fb00a5180ab
         with:
@@ -40,6 +46,7 @@ jobs:
           args: release --clean ${{ inputs.snapshot && '--snapshot' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,7 +50,7 @@ linters:
     - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library.
     - usetesting # Reports uses of functions with replacement inside the testing package.
     - whitespace # Whitespace is a linter that checks for unnecessary newlines at the start and end of functions, if, for, etc.
-    - wsl # Add or remove empty lines.
+    - wsl_v5 # Add or remove empty lines.
     ##################################################################################################
     # Enabled linters that require manual issue resolution
     - asasalint # Check for pass []any as any in variadic func(...any).

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,3 +67,23 @@ release:
     name: goGenerateCFToken
   draft: false
   prerelease: auto
+
+checksum:
+  name_template: checksums.txt
+
+signs:
+  - id: default
+    artifacts: all
+    args:
+      - "--batch"
+      - "--local-user"
+      - "nick@nickfedor.com"
+      - "--yes"
+      - "--pinentry-mode"
+      - "loopback"
+      - "--passphrase"
+      - "${GPG_PASSPHRASE}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -165,6 +165,7 @@ func TestGenerateCmd(t *testing.T) {
 			viper.Reset()
 
 			origInitConfig := config.InitConfigFunc
+
 			defer func() { config.InitConfigFunc = origInitConfig }()
 
 			config.InitConfigFunc = func(v config.Viper) {
@@ -183,6 +184,7 @@ func TestGenerateCmd(t *testing.T) {
 			}
 
 			origConfigFile := config.ConfigFile
+
 			defer func() { config.ConfigFile = origConfigFile }()
 
 			config.ConfigFile = tt.configFile
@@ -286,6 +288,7 @@ func TestGenerateCmd_BindErrors(t *testing.T) {
 			viper.Reset()
 
 			origBindPFlag := BindPFlagFunc
+
 			defer func() { BindPFlagFunc = origBindPFlag }()
 
 			if tt.name == "BindAPITokenFlagErrorMock" {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -173,6 +173,7 @@ func TestConfigPath(t *testing.T) {
 
 func TestRootCmd_ConfigFlag(t *testing.T) {
 	origConfigFile := config.ConfigFile
+
 	defer func() { config.ConfigFile = origConfigFile }()
 
 	config.ConfigFile = "test-config.yaml"

--- a/pkg/cloudflare/token.go
+++ b/pkg/cloudflare/token.go
@@ -63,8 +63,8 @@ func GenerateToken(
 	}}
 
 	// Specify resources to apply permissions to the zone.
-	resources := map[string]string{
-		"com.cloudflare.api.account.zone." + zoneID: "*",
+	resources := map[string]shared.TokenPolicyResourcesUnionParam{
+		"com.cloudflare.api.account.zone." + zoneID: shared.UnionString("*"),
 	}
 
 	// Configure token policy to allow the specified permissions and resources.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -84,6 +84,7 @@ func (m *mockViper) ConfigFileUsed() string {
 
 func TestInitConfig(t *testing.T) {
 	originalInitConfigFunc := InitConfigFunc
+
 	defer func() { InitConfigFunc = originalInitConfigFunc }()
 
 	called := false
@@ -98,6 +99,7 @@ func TestInitConfig(t *testing.T) {
 
 func TestInitConfig_NilFunc(t *testing.T) {
 	originalInitConfigFunc := InitConfigFunc
+
 	defer func() { InitConfigFunc = originalInitConfigFunc }()
 
 	viper.Reset()
@@ -311,6 +313,7 @@ func Test_setConfigFile(t *testing.T) {
 			osUserHomeDir = func() (string, error) { return tt.homeDir, tt.homeDirErr }
 
 			ConfigFile = tt.configFile
+
 			defer func() { ConfigFile = "" }()
 
 			err := setConfigFile(mock)


### PR DESCRIPTION
This pull request addresses a type mismatch issue in the Cloudflare token generation and enhances the project’s build process, linting configuration, and Git standardization.

## Changes

- **Fix Cloudflare token resource type mismatch**:
  - Update `pkg/cloudflare/token.go` to use `map[string]shared.TokenPolicyResourcesUnionParam` with `shared.UnionString("*")` for compatibility with `cloudflare-go/v4`.
  - Ensure compliance with the `TokenPolicyResourcesUnionParam` interface.

- **Update to `wsl_v5` linter in `.golangci.yaml`**:
  - Enable `wsl_v5` linter to enforce consistent newline formatting.
  - Apply resulting newline fixes to affected files for improved code consistency.

- **Enhance `.gitattributes` for standardization**:
  - Update `.gitattributes` to enforce consistent line endings and file handling.

- **Add GPG signing to release process**:
  - Configure `.goreleaser.yaml` to sign all artifacts using a GPG key.
  - Add checksum generation for release artifacts.
  - Update `build.yaml` to import GPG key using `crazy-max/ghaction-import-gpg` and pass `GPG_PASSPHRASE` for signing.