### PR TITLE
fix(renovate): use chore for go dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
       "matchDepNames": ["go"],
       "matchDepTypes": ["golang"],
       "rangeStrategy": "bump",
-      "semanticCommitType": "feat"
+      "semanticCommitType": "chore"
     },
     {
       "description": "Automerge non-major updates",


### PR DESCRIPTION
## Description
Updated Renovate configuration to use "chore" semantic commit type for Go dependency updates to align with Conventional Commits.

## Changes
- Modified `semanticCommitType` from "feat" to "chore" in `renovate.json` for `gomod` manager.