### PR TITLE
Fix Linter Issues in GitHub Actions Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,13 +46,13 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --config build/goreleaser/goreleaser.yaml --snapshot --clean ${{ fromJson(inputs.dry-run) && '--skip=publish' || '' }}
+          args: release --config build/goreleaser/goreleaser.yaml --snapshot --clean ${{ inputs.dry-run && '--skip=publish' || '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           DRY_RUN: ${{ inputs.dry-run }}
 
       - name: Upload binary SBOMs
-        if: ${{ !fromJson(inputs.dry-run) }}
+        if: ${{ !inputs.dry-run }}
         uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8
         with:
           name: binary-sboms
@@ -60,7 +60,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Generate artifact attestation
-        if: ${{ !fromJson(inputs.dry-run) }}
+        if: ${{ !inputs.dry-run }}
         uses: actions/attest-build-provenance@ff19f402b6e212671813b2ebe231d8a7c81ec049
         with:
           subject-checksums: ./dist/checksums.txt

--- a/.github/workflows/clean-cache.yaml
+++ b/.github/workflows/clean-cache.yaml
@@ -16,14 +16,13 @@ jobs:
       - name: Cleanup
         run: |
           echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
-
+          cacheKeysForPR=$(gh cache list --ref "$BRANCH" --limit 100 --json id --jq '.[].id')
           ## Setting this to not fail the workflow while deleting cache keys.
           set +e
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR
           do
-              gh cache delete $cacheKey
+              gh cache delete "$cacheKey"
           done
           echo "Done"
         env:


### PR DESCRIPTION
This pull request addresses linter issues identified by `actionlint` and `shellcheck` in the GitHub Actions workflows.

## Changes
- **build.yaml**: Removed unnecessary `fromJson` calls when evaluating the boolean `dry-run` input, as it is already a boolean and does not require parsing.
- **clean-cache.yaml**: Added double quotes around `$BRANCH` and `$cacheKey` variables in the shell script to prevent globbing and word splitting, as flagged by shellcheck.