### PR TITLE
ci: update Go version setup to use go.mod file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,8 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
-          check-latest: true
-          go-version: 1.25.x
+          go-version-file: "go.mod"
 
       - name: Install Syft for SBOM generation
         run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -17,8 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
-          check-latest: true
-          go-version: 1.25.x
+          go-version-file: "go.mod"
 
       - name: Install dependencies
         run: go mod download

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -19,7 +19,6 @@ permissions:
   security-events: write
 
 env:
-  GO_VERSION: 1.25.x
   OUTPUT_FILE: results.sarif
 
 jobs:
@@ -48,7 +47,7 @@ jobs:
         with:
           output-format: sarif
           output-file: ${{ env.OUTPUT_FILE }}
-          go-version-input: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@fe4161a26a8629af62121b670040955b330f9af2 # v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,8 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
-          check-latest: true
-          go-version: 1.25.x
+          go-version-file: "go.mod"
 
       - name: Install dependencies
         run: go mod download


### PR DESCRIPTION
This PR changes the designation of the Go version to use the go.mod file, rather than relying on less reliable methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflows to derive Go version from go.mod file instead of explicit version specifications. This ensures consistent tooling across all CI/CD pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->