### PR TITLE
ci: update security.yaml with go-version-input

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -48,6 +48,7 @@ jobs:
           output-format: sarif
           output-file: ${{ env.OUTPUT_FILE }}
           go-version-file: go.mod
+          go-version-input: ""
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@fe4161a26a8629af62121b670040955b330f9af2 # v4


### PR DESCRIPTION
Add unset go-version-input parameter to remove conflicting variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal development infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->