### PR TITLE
ci(actionlint): simplify lint workflow with actionlint-action

### DIFF
--- a/.github/workflows/lint-gh.yaml
+++ b/.github/workflows/lint-gh.yaml
@@ -1,34 +1,30 @@
+---
 name: Lint GitHub Actions Workflows
 
 on:
   workflow_dispatch: {}
-  push:
-    paths:
-      - .github/workflows
   pull_request:
+    branches:
+      - main
     paths:
-      - .github/workflows
+      - ".github/workflows/**"
 
 permissions:
-  contents: read
+  contents: read # Set default read-only permissions
 
 jobs:
-  lint-workflows:
+  actionlint:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the Runner (Step Security)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
 
-      - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - name: Download actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-        shell: bash
-
-      - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
-        shell: bash
+      - name: Run actionlint
+        uses: nicholas-fedor/actionlint-action@cfb3d059a17ba00c4b5717a9fa057fa434abb44f # v1.0.3


### PR DESCRIPTION
- replace manual actionlint download with nicholas-fedor/actionlint-action
- update checkout action to v6.0.2 with persist-credentials disabled
- rename job from lint-workflows to actionlint
- restrict pull_request trigger to main branch only
- update path filter to use glob pattern ".github/workflows/**"