### PR TITLE
test(config): use filepath.Join for cross-platform path assertions in config tests

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -117,12 +118,15 @@ func TestInitConfig_NilFunc(t *testing.T) {
 func Test_initConfig(t *testing.T) {
 	m := mocks.NewMockViper(t)
 
-	cfgFileUsed := "/test/config.yaml"
+	cfgFileUsed := filepath.Join("test", "config.yaml")
 
 	m.EXPECT().ConfigFileUsed().Return(cfgFileUsed)
 	m.EXPECT().ReadInConfig().Return(nil)
 
-	m.EXPECT().AddConfigPath("/home/test/.goGenerateCFToken")
+	homeDir := filepath.Join("home", "test")
+	expectedConfigPath := filepath.Join(homeDir, AppDirName)
+
+	m.EXPECT().AddConfigPath(expectedConfigPath)
 	m.EXPECT().AddConfigPath(".")
 	m.EXPECT().SetConfigName("config")
 	m.EXPECT().SetConfigType("yaml")
@@ -136,7 +140,7 @@ func Test_initConfig(t *testing.T) {
 
 	defer func() { osUserHomeDir = originalUserHomeDir }()
 
-	osUserHomeDir = func() (string, error) { return "/home/test", nil }
+	osUserHomeDir = func() (string, error) { return homeDir, nil }
 
 	var buf bytes.Buffer
 
@@ -162,8 +166,8 @@ func Test_initConfig(t *testing.T) {
 
 	output := buf.String()
 
-	if output != "Using config file: /test/config.yaml\n" {
-		t.Errorf("Expected output 'Using config file: /test/config.yaml\\n', got '%q'", output)
+	if output != "Using config file: "+cfgFileUsed+"\n" {
+		t.Errorf("Expected output 'Using config file: %s\\n', got '%q'", cfgFileUsed, output)
 	}
 }
 
@@ -233,13 +237,13 @@ func Test_setConfigFile(t *testing.T) {
 	}{
 		{
 			name:       "CustomConfigFile",
-			configFile: "/custom/config.yaml",
-			expectFile: "/custom/config.yaml",
+			configFile: filepath.Join("custom", "config.yaml"),
+			expectFile: filepath.Join("custom", "config.yaml"),
 		},
 		{
 			name:        "DefaultConfig",
-			homeDir:     "/home/test",
-			expectPaths: []string{"/home/test/.goGenerateCFToken", "."},
+			homeDir:     filepath.Join("home", "test"),
+			expectPaths: []string{filepath.Join(filepath.Join("home", "test"), AppDirName), "."},
 			expectName:  "config",
 			expectType:  "yaml",
 		},
@@ -319,8 +323,8 @@ func Test_loadConfig(t *testing.T) {
 	}{
 		{
 			name:           "ConfigFound",
-			configFileUsed: "/test/config.yaml",
-			expectOutput:   "Using config file: /test/config.yaml\n",
+			configFileUsed: filepath.Join("test", "config.yaml"),
+			expectOutput:   "Using config file: " + filepath.Join("test", "config.yaml") + "\n",
 		},
 		{
 			name:            "ConfigNotFound",


### PR DESCRIPTION
This PR updates test assertions for the config package to ensure cross-platform support.

## Problem

Running unit tests with a Windows-based runner exposed failures caused by hardcoded Unix filepath assertions.

## Solution

Update the assertions to use Go's `filepath.Join` method, which dynamically uses the correct path separators, based on the host OS.

## Changes

- Updated `config_test.go` to use `filepath.Join` to construct filepaths for test assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated configuration tests with improved path handling in test expectations and mocked values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/goGenerateCFToken/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->