### PR TITLE
build(docker): remove healthcheck

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -18,6 +18,4 @@ COPY --chmod=0755 ${TARGETPLATFORM}/gogeneratecftoken /gogeneratecftoken
 
 USER 65532:65532
 
-HEALTHCHECK CMD ["/gogeneratecftoken", "--health-check"]
-
 ENTRYPOINT ["/gogeneratecftoken"]


### PR DESCRIPTION
This PR removes an erroneous healthcheck that is unused, as it was a remnant from copying the Dockerfile from another project.

## Changes

- Remove unused healthcheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Docker image health check configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/goGenerateCFToken/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->